### PR TITLE
Ansible variables not replaced in config files (sccm-sitesrv)

### DIFF
--- a/roles/ludus_sccm_siteserver/defaults/main.yml
+++ b/roles/ludus_sccm_siteserver/defaults/main.yml
@@ -52,7 +52,7 @@ ludus_domain_join_password: 'password'
 ludus_sccm_system_management_template: SystemManagement.ps1.j2
 
 ludus_sccm_win_sccm_config_default_template: ConfigMgrSetup.ini.j2
-ludus_sccm_win_sccm_config_default_prereq_path: C:\SCCM 
+ludus_sccm_win_sccm_config_default_prereq_path: C:\ludus\sccm\cd.retail.LN\SMSSETUP\BIN\X64
 
 ludus_sccm_configmgr_url: https://download.microsoft.com/download/0/0/1/001d97e2-c427-4d4b-ad30-1556ee0ff1b0/MCM_Configmgr_2303.exe
 

--- a/roles/ludus_sccm_siteserver/tasks/install_sccm.yml
+++ b/roles/ludus_sccm_siteserver/tasks/install_sccm.yml
@@ -57,12 +57,12 @@
     ansible_become_flags: "logon_type=interactive logon_flags=with_profile"
 
 - name: Template ConfigMgrSetup.ini
-  ansible.windows.win_template:
+  ansible.builtin.template:
     src: "{{ ludus_sccm_win_sccm_config_default_template }}"
     dest: "C:\\ludus\\sccm\\ConfigMgrSetup.ini"
 
 - name: Template SystemManagement.ps1
-  ansible.windows.win_template:
+  ansible.builtin.template:
     src: "{{ ludus_sccm_system_management_template }}"
     dest: "C:\\ludus\\sccm\\SystemManagement.ps1"
 


### PR DESCRIPTION
Quick patch for `roles/ludus_sccm_siteserver/tasks/install_sccm.yml` and `roles/ludus_sccm_siteserverdefaults/main.yml`

`install_sccm.yml`
- `ansible.windows.win_template` is deprecated in later versions of ansible
- this leads to the ansible variables not being replaced when they are dropped onto sccm-sitesrv
- because `ConfigMgrSetup.ini` still contains the ansible variables, `SetupWpf.exe` will fail when reading
- variables inside of `SystemManagement.ps1` are also not replaced prior to being pushed to the system

`main.yml`
- currently points to `C:\SCCM` as the PrerequisitePath
- this is updated to point to the correct path where everything is dropped on the remote system

tested against
```
a@ludus:~$ ludus version
[INFO]  Ludus client 2.0.7+b3f486f
[INFO]  Ludus Server 2.0.7+b3f486f - community license
a@ludus:~$ ansible --version
ansible [core 2.19.4]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/a/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/a/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.13.5 (main, Jun 25 2025, 18:55:22) [GCC 14.2.0] (/usr/bin/python3)
  jinja version = 3.1.6
  pyyaml version = 6.0.2 (with libyaml v0.2.5)
```